### PR TITLE
Update for ansible galaxy.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '5 2 * * 6'
 
+defaults:
+  run:
+    working-directory: 'glillico.auto_pkg_updates'
+
 jobs:
   lint:
     name: Lint
@@ -16,6 +20,8 @@ jobs:
     steps:
       - name: Check out git repository.
         uses: actions/checkout@v2
+        with:
+          path: 'glillico.auto_pkg_updates'
 
       - name: Setup python 3.
         uses: actions/setup-python@v2
@@ -40,9 +46,10 @@ jobs:
         distro:
           - amazonlinux2
           - centos7
-          - centos8
+          - rockylinux8
           - debian9
           - debian10
+          - debian11
           - ubuntu1804
           - ubuntu2004
         tag:
@@ -50,6 +57,8 @@ jobs:
     steps:
       - name: Check out git repository.
         uses: actions/checkout@v2
+        with:
+          path: 'glillico.auto_pkg_updates'
 
       - name: Setup python 3.
         uses: actions/setup-python@v2

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,8 +7,12 @@ galaxy_info:
   platforms:
     - name: Debian
       versions:
-        - 10
-        - 9
+        - stretch
+        - buster
+    - name: Ubuntu
+      versions:
+        - bionic
+        - focal
     - name: EL
       versions:
         - 7

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,7 @@ galaxy_info:
       versions:
         - stretch
         - buster
+        - bullseye
     - name: Ubuntu
       versions:
         - bionic

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -2,7 +2,6 @@
 - name: Converge
   hosts: all
   become: true
-  tasks:
-    - name: "Include ansible-role-auto_pkg_updates"
-      include_role:
-        name: "ansible-role-auto_pkg_updates"
+
+  roles:
+    - role: glillico.auto_pkg_updates

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,7 +5,7 @@ driver:
   name: docker
 platforms:
   - name: instance
-    image: "glillico/docker-${MOLECULE_DISTRO:-centos7}-ansible:${MOLECULE_TAG:-latest}"
+    image: "glillico/docker-${MOLECULE_DISTRO:-rockylinux8}-ansible:${MOLECULE_TAG:-latest}"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro


### PR DESCRIPTION
- Updated ansible galaxy meta information.
- Update ansible galaxy meta file.
- Update molecule to use ansible galaxy name format.
- Update github ci to use ansible galaxy name format.
- Make rockylinux8 the default image molecule will use.
